### PR TITLE
Created requirements.txt to manage dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Midi-AI-Melody-Generator
 Uses LSTM neural networks to compose new and original melodies by feeding it midi files
 
-## Dependencies
+## Getting Started
+This repo is only compatible with `Python 2.7` and a `pip` that points to this version.
 
-- [python-midi](https://github.com/vishnubob/python-midi): `pip install python-midi`
-- [MIDIUtil](https://code.google.com/p/midiutil): `pip install MIDIUtil`
-- [pybrain](http://pybrain.org/): `pip install pybrain`
+To install all dependencies, run:
+`python -m pip install -r requirements.txt`
 
 ## Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+python-midi==0.2.4
+MIDIUtil==1.2.1
+PyBrain==0.3


### PR DESCRIPTION
I migrated the list of dependencies to a `requirements.txt` file so that the versions can be pinned. This is how I got my local working (works great!) to confirm that this behaves as expected.